### PR TITLE
Update User Guide add command for role and notes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -83,6 +83,8 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​ [r/ROLE] [nt/
 A person can have any number of tags (including 0). Role and notes are optional.
 </div>
 
+* A person is considered a duplicate if the phone number matches exactly, or the email matches case-insensitively.
+
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 r/Usher nt/Weekend only`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal r/Logistics nt/Prefers morning shifts`


### PR DESCRIPTION
## Summary
Updates the User Guide so the add command documentation matches current RosterBolt behavior. Fixes #52 

## Changes
- updated add command format to include `r/ROLE` and `nt/NOTES`
- added examples showing role and notes usage
- updated command summary entry for add