### PR TITLE
Fix alias commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -95,7 +95,8 @@ public class AliasCommand extends Command {
         }
 
         model.setCommandAlias(shortName, targetCommandWord);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, shortName, targetCommandWord));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, shortName, targetCommandWord),
+                personListView);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AliasesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasesCommand.java
@@ -27,7 +27,7 @@ public class AliasesCommand extends Command {
 
         Map<String, String> aliases = model.getCommandAliases();
         if (aliases.isEmpty()) {
-            return new CommandResult(MESSAGE_NO_ALIASES);
+            return new CommandResult(MESSAGE_NO_ALIASES, personListView);
         }
 
         String aliasList = aliases.entrySet().stream()
@@ -35,6 +35,7 @@ public class AliasesCommand extends Command {
                 .map(entry -> entry.getKey() + " -> " + entry.getValue())
                 .collect(Collectors.joining("\n"));
 
-        return new CommandResult(MESSAGE_ALIASES_HEADER + "\n" + aliasList);
+        return new CommandResult(MESSAGE_ALIASES_HEADER + "\n" + aliasList,
+                personListView);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnaliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnaliasCommand.java
@@ -42,7 +42,7 @@ public class UnaliasCommand extends Command {
         }
 
         model.removeCommandAlias(shortName);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, shortName));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, shortName), personListView);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.PersonListView;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
@@ -42,13 +43,29 @@ public class AliasCommandTest {
     }
 
     @Test
-    public void execute_validAlias_success() {
+    public void execute_validAliasWhileViewingKeptPersons_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
         expectedModel.setCommandAlias("ls", ListCommand.COMMAND_WORD);
 
         assertCommandSuccess(new AliasCommand("ls", ListCommand.COMMAND_WORD), model,
-                String.format(AliasCommand.MESSAGE_SUCCESS, "ls", ListCommand.COMMAND_WORD), expectedModel);
+                PersonListView.KEPT_PERSONS,
+                String.format(AliasCommand.MESSAGE_SUCCESS, "ls", ListCommand.COMMAND_WORD),
+                PersonListView.KEPT_PERSONS, expectedModel);
+    }
+
+    @Test
+    public void execute_validAliasWhileViewingDeletedPersons_success() {
+        // This is the only test case where we view the list of deleted persons before command execution,
+        // as the main logic of the command should be identical regardless of the viewed list.
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+        expectedModel.setCommandAlias("ls", ListCommand.COMMAND_WORD);
+
+        assertCommandSuccess(new AliasCommand("ls", ListCommand.COMMAND_WORD), model,
+                PersonListView.DELETED_PERSONS,
+                String.format(AliasCommand.MESSAGE_SUCCESS, "ls", ListCommand.COMMAND_WORD),
+                PersonListView.DELETED_PERSONS, expectedModel);
     }
 
     @Test
@@ -58,7 +75,9 @@ public class AliasCommandTest {
         expectedModel.setCommandAlias("wipe", ClearCommand.COMMAND_WORD);
 
         assertCommandSuccess(new AliasCommand("wipe", ClearCommand.COMMAND_WORD), model,
-                String.format(AliasCommand.MESSAGE_SUCCESS, "wipe", ClearCommand.COMMAND_WORD), expectedModel);
+                PersonListView.KEPT_PERSONS,
+                String.format(AliasCommand.MESSAGE_SUCCESS, "wipe", ClearCommand.COMMAND_WORD),
+                PersonListView.KEPT_PERSONS, expectedModel);
     }
 
     @Test
@@ -67,7 +86,7 @@ public class AliasCommandTest {
         model.setCommandAlias("ls", ListCommand.COMMAND_WORD);
 
         assertCommandFailure(new AliasCommand("ls", HelpCommand.COMMAND_WORD), model,
-                AliasCommand.MESSAGE_DUPLICATE_ALIAS);
+                PersonListView.KEPT_PERSONS, AliasCommand.MESSAGE_DUPLICATE_ALIAS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AliasesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasesCommandTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.PersonListView;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
@@ -17,7 +18,10 @@ public class AliasesCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new AliasesCommand(), model, AliasesCommand.MESSAGE_NO_ALIASES, expectedModel);
+        assertCommandSuccess(new AliasesCommand(), model, PersonListView.KEPT_PERSONS,
+                AliasesCommand.MESSAGE_NO_ALIASES, PersonListView.KEPT_PERSONS, expectedModel);
+        assertCommandSuccess(new AliasesCommand(), model, PersonListView.DELETED_PERSONS,
+                AliasesCommand.MESSAGE_NO_ALIASES, PersonListView.DELETED_PERSONS, expectedModel);
     }
 
     @Test
@@ -34,6 +38,9 @@ public class AliasesCommandTest {
                 + "\nls -> " + ListCommand.COMMAND_WORD
                 + "\nrm -> " + DeleteCommand.COMMAND_WORD;
 
-        assertCommandSuccess(new AliasesCommand(), model, expectedMessage, expectedModel);
+        assertCommandSuccess(new AliasesCommand(), model, PersonListView.KEPT_PERSONS,
+                expectedMessage, PersonListView.KEPT_PERSONS, expectedModel);
+        assertCommandSuccess(new AliasesCommand(), model, PersonListView.DELETED_PERSONS,
+                expectedMessage, PersonListView.DELETED_PERSONS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UnaliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnaliasCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.PersonListView;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
@@ -24,20 +25,35 @@ public class UnaliasCommandTest {
     }
 
     @Test
-    public void execute_existingAlias_success() {
+    public void execute_existingAliasWhileViewingKeptPersons_success() {
         Model model = new ModelManager();
         model.setCommandAlias("ls", ListCommand.COMMAND_WORD);
         Model expectedModel = new ModelManager();
 
         assertCommandSuccess(new UnaliasCommand("ls"), model,
-                String.format(UnaliasCommand.MESSAGE_SUCCESS, "ls"), expectedModel);
+                PersonListView.KEPT_PERSONS,
+                String.format(UnaliasCommand.MESSAGE_SUCCESS, "ls"),
+                PersonListView.KEPT_PERSONS, expectedModel);
+    }
+
+    @Test
+    public void execute_existingAliasWhileViewingDeletedPersons_success() {
+        Model model = new ModelManager();
+        model.setCommandAlias("ls", ListCommand.COMMAND_WORD);
+        Model expectedModel = new ModelManager();
+
+        assertCommandSuccess(new UnaliasCommand("ls"), model,
+                PersonListView.DELETED_PERSONS,
+                String.format(UnaliasCommand.MESSAGE_SUCCESS, "ls"),
+                PersonListView.DELETED_PERSONS, expectedModel);
     }
 
     @Test
     public void execute_missingAlias_throwsCommandException() {
         Model model = new ModelManager();
 
-        assertCommandFailure(new UnaliasCommand("ls"), model, UnaliasCommand.MESSAGE_ALIAS_NOT_FOUND);
+        assertCommandFailure(new UnaliasCommand("ls"), model, PersonListView.KEPT_PERSONS,
+                UnaliasCommand.MESSAGE_ALIAS_NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
- Let alias commands (`alias`, `aliases`, `unalias`) show the user the same list before and after execution -- see #158 
- Use non-deprecated methods -- see #142 