### PR TITLE
Fix editprev command

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -63,11 +63,6 @@ public class LogicManager implements Logic {
         Command command = addressBookParser.parseCommand(expandedCommandText);
         CommandResult commandResult = command.execute(model, personListView);
 
-        // EditPreviousCommand preserves the current view instead of switching.
-        if (command instanceof EditPreviousCommand) {
-            commandResult = replacePersonListView(commandResult, personListView);
-        }
-
         String saveFailureMessage = null;
         try {
             storage.saveAddressBook(model.getAddressBook());
@@ -157,18 +152,6 @@ public class LogicManager implements Logic {
             startupMessage = Optional.of(String.format(MESSAGE_INVALID_ALIASES_REMOVED_ON_STARTUP,
                     String.join(", ", invalidAliases)));
         }
-    }
-
-    /**
-     * Returns a new {@code CommandResult} with the same fields but a different {@code PersonListView}.
-     */
-    private static CommandResult replacePersonListView(CommandResult result, PersonListView personListView) {
-        return new CommandResult(
-                result.getFeedbackToUser(),
-                personListView,
-                result.shouldShowHelp(),
-                result.shouldExit(),
-                result.getCommandTextToPopulate().orElse(null));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditPreviousCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPreviousCommand.java
@@ -32,7 +32,7 @@ public class EditPreviousCommand extends Command {
 
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, lastCommandText),
-                PersonListView.KEPT_PERSONS,
+                personListView,
                 false,
                 false,
                 lastCommandText);

--- a/src/test/java/seedu/address/logic/commands/EditPreviousCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPreviousCommandTest.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.PersonListView;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+/**
+ * Contains tests for EditPreviousCommand.
+ */
+public class EditPreviousCommandTest {
+
+    private static final String LAST_COMMAND_TEXT = "list";
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager();
+        expectedModel = new ModelManager();
+    }
+
+    @Test
+    public void execute_noPreviousCommand_throwsCommandException() {
+        assertCommandFailure(new EditPreviousCommand(), model, PersonListView.KEPT_PERSONS,
+                EditPreviousCommand.MESSAGE_NO_PREVIOUS_COMMAND);
+        assertCommandFailure(new EditPreviousCommand(), model, PersonListView.DELETED_PERSONS,
+                EditPreviousCommand.MESSAGE_NO_PREVIOUS_COMMAND);
+    }
+
+    @Test
+    public void execute_previousCommandExistsViewingKeptPersons_success() {
+        model.setLastCommandText(LAST_COMMAND_TEXT);
+        CommandResult expectedCommandResult = new CommandResult(
+                String.format(EditPreviousCommand.MESSAGE_SUCCESS, LAST_COMMAND_TEXT),
+                PersonListView.KEPT_PERSONS,
+                false,
+                false,
+                LAST_COMMAND_TEXT);
+
+        assertCommandSuccess(new EditPreviousCommand(), model, PersonListView.KEPT_PERSONS,
+                expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_previousCommandExistsViewingDeletedPersons_success() {
+        model.setLastCommandText(LAST_COMMAND_TEXT);
+        CommandResult expectedCommandResult = new CommandResult(
+                String.format(EditPreviousCommand.MESSAGE_SUCCESS, LAST_COMMAND_TEXT),
+                PersonListView.DELETED_PERSONS,
+                false,
+                false,
+                LAST_COMMAND_TEXT);
+
+        assertCommandSuccess(new EditPreviousCommand(), model, PersonListView.DELETED_PERSONS,
+                expectedCommandResult, expectedModel);
+    }
+}
+


### PR DESCRIPTION
Using the old `command#execute` interface, the `editprev` command has to jump through hoops in `LogicManager` to ensure that the viewed list remains the same after command execution.

Let's
- streamline the process by moving this behaviour into `command#execute` like other commands.
- add tests.