### PR TITLE
Rename working list to contact list

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -550,6 +550,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 |             Alias             | A user-defined shortcut that maps a short command word to a supported built-in command word.                                     |
 |      Availability Window      | The time period during which a volunteer is available to participate in events.                                                  |
 |        Bulk Operation         | An operation that applies to multiple contacts within a single command (e.g., deleting or assigning several volunteers at once). |
+|        Contact List           | The main list of active (non-deleted) contacts, as opposed to the recycle bin.                                                   |
 | CSV (Comma-Separated Values)  | A text file format used to store tabular data, used by the system for importing or exporting volunteer data.                     |
 |       Duplicate Contact       | A contact that shares critical identifying fields (e.g., phone number or email address) with an existing contact in the system.  |
 |         Mainstream OS         | Windows, Linux, Unix, macOS.                                                                                                     |
@@ -560,7 +561,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 |              Tag              | A user-defined label used to categorize volunteers (e.g., “first-aid”, “logistics”).                                             |
 |    Volunteer Availability     | A recurring weekly time slot (day, start time, end time) during which a volunteer is available.                                  |
 |      Volunteer Record         | A datetime range (start and end) representing a period during which a volunteer has served.                                      |
-|        Working List           | The main list of active (non-deleted) contacts, as opposed to the recycle bin.                                                   |
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -111,7 +111,7 @@ Format: `help`
 
 Adds a new volunteer to your RosterBolt contact list.
 
-You must be viewing the working list to use this command. Otherwise, you'll see an error message and the volunteer won't be added.
+You must be viewing the contact list to use this command. Otherwise, you'll see an error message and the volunteer won't be added.
 
 Format: `add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]…​ [r/ROLE] [nt/NOTES] [va/AVAILABILITY]…​ [vr/RECORD]…​`
 
@@ -194,7 +194,7 @@ Format: `bin`
 
 Edits the details of a volunteer that's already in your RosterBolt contact list. Use this when a volunteer changes their phone number, email, availability, or any other information.
 
-You must be viewing the working list to use this command. Otherwise, you'll see an error message and no changes will be made.
+You must be viewing the contact list to use this command. Otherwise, you'll see an error message and no changes will be made.
 
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [r/ROLE] [nt/NOTES] [t/TAG]…​ [va/AVAILABILITY]…​ [vr/RECORD]…​`
 
@@ -213,7 +213,7 @@ Examples:
 
 Finds volunteers in your RosterBolt contact list matching any of the given keywords, with an optional filter for availability. This is handy when you need to quickly find a specific volunteer, or locate everyone who's free on a particular day and time for an upcoming event.
 
-You can use this command while viewing either the working list or the recycle bin, and RosterBolt will search within the currently displayed list.
+You can use this command while viewing either the contact list or the recycle bin, and RosterBolt will search within the currently displayed list.
 
 Format: `find [m/MATCH_TYPE] [va/DAY,HH:mm,HH:mm] [KEYWORD [MORE_KEYWORDS]]`
 
@@ -246,7 +246,7 @@ Examples:
 
 Displays a quick overview of your volunteer roster through text-based charts. Use this to spot patterns, like which roles are understaffed or who your most active volunteers are.
 
-You can use this command while viewing either the working list or the recycle bin, but RosterBolt will always calculate the statistics based on the working list, and switch your view to the working list.
+You can use this command while viewing either the contact list or the recycle bin, but RosterBolt will always calculate the statistics based on the full contact list, and switch your view to the contact list.
 
 Format: `stats CATEGORY`
 
@@ -262,7 +262,7 @@ Examples:
 
 Deletes volunteer(s) from your RosterBolt contact list. Don't worry, deleted volunteers are moved to the recycle bin, so you can [restore](#restoring-a-deleted-volunteer--restore) them if needed.
 
-You must be viewing the working list to use this command. Otherwise, you'll see an error message and no volunteer(s) will be deleted.
+You must be viewing the contact list to use this command. Otherwise, you'll see an error message and no volunteer(s) will be deleted.
 
 Format: `delete INDEX [MORE_INDICES]`
 
@@ -301,7 +301,7 @@ Examples:
 
 Imports volunteers in bulk from a CSV (spreadsheet) file. This is useful when onboarding a large group of new volunteers at once, or migrating data from another tool.
 
-You can use this command while viewing either the working list or the recycle bin, but RosterBolt will always import volunteers into the working list, and switch your view to the working list.
+You can use this command while viewing either the contact list or the recycle bin, but RosterBolt will always import volunteers into the contact list, and switch your view to the contact list.
 
 Format: `import FILE_PATH`
 
@@ -324,7 +324,7 @@ Examples:
 
 Exports all your active volunteers to a CSV (spreadsheet) file. This is useful for creating backups, sharing your roster with others, or working with the data in spreadsheet software like Excel or Google Sheets.
 
-You can use this command while viewing either the working list or the recycle bin, but RosterBolt will always export volunteers in the working list, and switch your view to the working list.
+You can use this command while viewing either the contact list or the recycle bin, but RosterBolt will always export volunteers in the full contact list, and switch your view to the contact list.
 
 Format: `export FILE_PATH`
 
@@ -337,7 +337,7 @@ Examples:
 
 Clears all volunteers from your active contact list at once. This is a quick way to start fresh, as all removed volunteers are moved to the recycle bin so you can still [restore](#restoring-a-deleted-volunteer--restore) them before closing the app.
 
-You must be viewing the working list to use this command. Otherwise, you'll see an error message and your contacts won't be cleared.
+You must be viewing the contact list to use this command. Otherwise, you'll see an error message and your contacts won't be cleared.
 
 Format: `clear`
 


### PR DESCRIPTION
Replace all instances of "working list" with "contact list", meaning the list of kept volunteers.