### PR TITLE
Add UI element showing which list is displayed

### DIFF
--- a/src/main/java/seedu/address/logic/PersonListView.java
+++ b/src/main/java/seedu/address/logic/PersonListView.java
@@ -5,5 +5,16 @@ package seedu.address.logic;
  */
 public enum PersonListView {
     KEPT_PERSONS,
-    DELETED_PERSONS
+    DELETED_PERSONS;
+
+    public String getDisplayMessage() {
+        switch (this) {
+        case KEPT_PERSONS:
+            return "You are viewing your contact list of active volunteers.";
+        case DELETED_PERSONS:
+            return "You are viewing your recycle bin of recently deleted volunteers.";
+        default:
+            throw new IllegalStateException("Unexpected value of personListView: " + this);
+        }
+    }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -115,7 +115,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredKeptPersonList());
+        personListPanel = new PersonListPanel(personListView.getDisplayMessage(), selectPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
@@ -199,16 +199,19 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
-    private void updatePersonListPanel() {
+    private ObservableList<Person> selectPersonList() {
         // Indented case blocks in lambda-style switch statements are allowed
         // CHECKSTYLE.OFF: Indentation
-        ObservableList<Person> personList = switch (personListView) {
+        return switch (personListView) {
             case KEPT_PERSONS -> logic.getFilteredKeptPersonList();
             case DELETED_PERSONS -> logic.getFilteredDeletedPersonList();
             default -> throw new IllegalStateException("Unexpected value of personListView: " + personListView);
         };
         // CHECKSTYLE.ON: Indentation
+    }
 
-        personListPanel.setPersonList(personList);
+    private void updatePersonListPanel() {
+        personListPanel.setPersonListStatus(personListView.getDisplayMessage());
+        personListPanel.setPersonList(selectPersonList());
     }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -19,16 +21,28 @@ public class PersonListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
     @FXML
+    private Label personListStatus;
+
+    @FXML
     private ListView<Person> personListView;
 
     /**
-     * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
+     * Creates a {@code PersonListPanel} with the given status text and {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(String status, ObservableList<Person> personList) {
         super(FXML);
+        requireNonNull(status);
+        requireNonNull(personList);
+
+        setPersonListStatus(status);
+
         personListView.setPlaceholder(new Label("No contacts to display."));
         setPersonList(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+    }
+
+    public void setPersonListStatus(String status) {
+        personListStatus.setText(status);
     }
 
     /**

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <Label fx:id="personListStatus" styleClass="label-bright" />
   <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>


### PR DESCRIPTION
Let's tell the user which list is being displayed at any given time, so that:

- users don't have to memorize which list they are looking at; and
- users can more easily understand errors caused by running or attempting to run commands on the wrong list.

I think this addresses the point about user confusion in #197.

**LoC Changes to functional code: +37, -7**

See example screenshots below. Note that we would have to update most/all existing screenshots in docs.

<img width="1098" height="891" alt="image" src="https://github.com/user-attachments/assets/6f69c743-7c73-4240-9f67-dcbc541e039c" />

<img width="1098" height="891" alt="image" src="https://github.com/user-attachments/assets/18cb7ec1-0f23-4378-8807-6d7b8f1fbfb3" />

