### PR TITLE
Reset predicate after modifying contacts

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -130,11 +130,13 @@ public class ModelManager implements Model {
     @Override
     public void deletePerson(Person target) {
         addressBook.deletePerson(target);
+        updateFilteredKeptPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
     public void restorePerson(Person target) {
         addressBook.restorePerson(target);
+        updateFilteredDeletedPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
@@ -148,11 +150,13 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setKeptPerson(target, editedPerson);
+        updateFilteredKeptPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
     public void deleteAllPersons() {
         addressBook.deleteAllPersons();
+        updateFilteredKeptPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -165,7 +165,6 @@ public class DeleteCommandTest {
 
         assertCommandSuccess(deleteCommand, model, PersonListView.KEPT_PERSONS,
                 expectedMessage, PersonListView.KEPT_PERSONS, expectedModel);
-        assertEquals(List.of(secondPersonToRemain), model.getFilteredKeptPersonList());
     }
 
     @Test


### PR DESCRIPTION
Address #205 

I made this a Model component change instead of a Logic one. In ModelManager#addPerson, the existing code already resets the filter in addition to adding the person. This PR resets the filter for all other methods modifying person lists in ModelManager.

LoC changes to functional code: +4